### PR TITLE
refactor the theme to more comprehensive standards

### DIFF
--- a/organic-green-theme.el
+++ b/organic-green-theme.el
@@ -167,6 +167,7 @@ The theme needs to be reloaded after changing anything in this group."
    `(link ((,class (:underline t :foreground ,organic-blue-6))))
    `(link-visited ((,class (:underline t :foreground ,organic-blue-4))))
    `(highlight ((,class (:background ,organic-green-1))))
+   `(hl-line ((,class (:background ,organic-green-2 :inverse-video nil))))
    `(region ((,class (:background ,organic-yellow-1))))
    `(lazy-highlight ((,class (:background ,organic-yellow-2 :inverse-video nil))))
    `(isearch ((,class (:foreground ,organic-fg :background ,organic-yellow-3 :inverse-video nil))))

--- a/organic-green-theme.el
+++ b/organic-green-theme.el
@@ -25,361 +25,376 @@
 
 ;;; Code:
 
-(make-face 'tcl-substitution-char-face)
+(deftheme organic-green "Low-contract green color theme.")
 
-(defcustom organic-green-boldless nil
-  "When t set all fonts from bold to normal."
+(defgroup organic-green nil
+  "Organic-green theme customization.
+The theme needs to be reloaded after changing anything in this group."
+  :group 'faces)
+
+(defcustom organic-green-bold-constructs nil
+  "Use bold text in more code constructs."
   :type 'boolean
-  :group 'organic-green-theme)
+  :group 'organic-green)
 
-(deftheme organic-green
-  "Low-contrast green color theme.
-Basic, Font Lock, Isearch, Jabber, rst, magit, Web faces are included.")
-(labels ((set-bold (bold-factor) (if organic-green-boldless
-                                     'normal
-                                   (or bold-factor 'bold))))
-  (let* ((class '((class color) (min-colors 89)))
-         ;; basic colors
-         (organic-fg                    "#326B6B")
-         (organic-bg                    "#F0FFF0")
-         (organic-cursor-fg             "#225522")
+(defcustom organic-green-slanted-constructs nil
+  "Use slanted text in more code constructs (italics or oblique)."
+  :type 'boolean
+  :group 'organic-green)
 
-         ;; palette colors
-         (organic-grass-green          "#119911")
-         (organic-spring-green         "#008B45")
-         (organic-sea-eye-green        "#00A86B")
-         (organic-success-green        "#4e9a06")
-         (organic-teal                 "#009292")
-         (organic-olive                "#6E8B3D")
+(let ((class '((class color) (min-colors 89)))
+      (organic-fg "#326B6B")
+      (organic-bg        "#F0FFF0")
+      (organic-cursor-fg "#225522")
+      (organic-fringe-bg "#E5E5E5")
+      (organic-fringe-fg "gray40")
 
-         (organic-blue                 "#3063EA")
-         (organic-flx-blue             "#0066CC")
-         (organic-dodger-blue          "#1874CD")
-         (organic-light-blue           "#8cc4ff")
-         (organic-medium-blue          "#3465BD")
-         (organic-dark-blue            "#204a87")
-         (organic-cornflower-blue      "#4045F0")
+      ;; base color pallet
+      (organic-white     "white")
 
-         (organic-purple (if organic-green-boldless "#912CEE" "#A020F0"))
-         (organic-yellow               "#B8860B")
-         (organic-dark-yellow          "#8B6508")
-         (organic-orange               "#CE5C00")
-         (organic-error-red            "#A40000")
+      (organic-teal      "#009292")
+      (organic-olive-0   "#6E8B3D")
+      (organic-olive-1   "DarkOliveGreen")
 
-         (organic-gray                 "gray50")
-         (organic-dark-gray            "grey28")
+      (organic-green-0   "#E3FFE1")
+      (organic-green-1   "#D5F0D5")
+      (organic-green-2   "#A0F0A0")
+      (organic-green-3   "#4e9a06")
+      (organic-green-4   "#119911")
+      (organic-green-5   "#339933")
+      (organic-green-6   "#008B45")
+      (organic-green-7   "#22aa22")
+      (organic-green-8   "#00A86B")
+      (organic-green-9   "dark sea green")
 
-         (alum-1         "#eeeeec")
-         (alum-2         "#d3d7cf")
-         (alum-3         "#babdb6")
-         (alum-6         "#2e3436")
+      ;; #cceecc
+      ;; #ddffdd
+      ;; #118811
+      ;; PaleGreen3
 
-         (red-1          "#ef2929")
-         (red-2          "#cc0000")
+      (organic-blue-0    "#8cc4ff")
+      (organic-blue-1    "#1874CD")
+      (organic-blue-2    "#3063EA")
+      (organic-blue-3    "#0066CC")
+      (organic-blue-4    "#3465BD")
+      (organic-blue-5    "#4045F0")
+      (organic-blue-6    "#204a87")
 
-         (organic-pair-yellow            "#F0F0A1")
-         (organic-highlight-yellow       "#EEEEA0")
-         (organic-highlight-lazy-yellow  "#DDEE00")
-         (organic-highlight-green        "#A0F0A0")
-         (organic-highlight-yellow-green "#BFFF00")
+      ;; LightSkyBlue3
 
-         (organic-minor-highlight-green  "#D5F0D5")
-         (organic-tiny-highlight-green   "#E3FFE1")
-         (organic-minor-highlight-grey   "#DAEADA")
-         (organic-tiny-highlight-grey    "#E3F2E1")
-         (organic-minor-highlight-yellow "#F2FFC0")
-         (organic-minor-highlight-red    "#FFF0F0"))
+      (organic-yellow-0  "#f2ffc0") ;
+      (organic-yellow-1  "#F0F0A1")
+      (organic-yellow-2  "#DDEE00")
+      (organic-yellow-3  "yellow")
+      (organic-yellow-4  "#8B6508")
+      (organic-yellow-5  "#B8860B")
 
-    (custom-theme-set-faces
-     'organic-green
-     `(default ((,class (:foreground ,organic-fg :background ,organic-bg))))
-     `(cursor ((,class (:background ,organic-cursor-fg))))
-     `(hl-line ((,class (:background ,organic-highlight-green :inverse-video nil))))
 
-     ;; Highlighting faces
-     `(fringe ((,class (:background "#E5E5E5" :foreground "gray40"))))
-     `(highlight ((,class (:background ,organic-minor-highlight-green))))
-     `(region ((,class (:background ,organic-highlight-yellow))))
-     `(cua-rectangle ((,class (:background ,organic-highlight-yellow-green))))
-     `(secondary-selection ((,class (:background ,organic-light-blue))))
-     `(isearch ((,class (:foreground ,organic-fg :background "yellow" :inverse-video nil))))
-     `(lazy-highlight ((,class (:background ,organic-highlight-lazy-yellow :inverse-video nil))))
-     `(trailing-whitespace ((,class (:background ,red-1))))
+      (organic-purple    (if        organic-green-bold-constructs "#912CEE" "#A020F0"))
+      (organic-orange    "#CE5C00")
 
-     ;; Mode line faces
-     `(mode-line ((,class (:box (:line-width -1 :style released-button)
-                                :background ,alum-2 :foreground ,alum-6))))
-     `(mode-line-inactive ((,class (:box (:line-width -1 :style released-button)
-                                         :background ,alum-1 :foreground ,alum-6))))
+      (organic-red-0     "#FFF0F0")
+      (organic-red-1     "#ffdddd")
+      (organic-red-2     "#eecccc")
+      (organic-red-3     "#ef2929")
+      (organic-red-4     "red")
+      (organic-red-5     "#cc0000")
+      (organic-red-6     "#A40000")
 
-     ;; Escape and prompt faces
-     `(minibuffer-prompt ((,class (:weight bold :foreground ,organic-dark-blue))))
-     `(escape-glyph ((,class (:foreground ,organic-sea-eye-green))))
-     `(error ((,class (:foreground ,organic-error-red :weight ,(set-bold 'bold)))))
-     `(warning ((,class (:foreground ,organic-orange))))
-     `(success ((,class (:foreground ,organic-success-green))))
+      ;; tomato1
 
-     ;; Font lock faces
-     `(font-lock-builtin-face ((,class (:foreground ,organic-teal))))
-     `(font-lock-comment-face ((,class (:foreground ,organic-gray))))
-     `(font-lock-constant-face ((,class (:foreground ,organic-medium-blue))))
-     `(font-lock-function-name-face ((,class (:weight ,(set-bold 'extra-bold) :foreground ,organic-blue))))
-     `(font-lock-keyword-face ((,class (:weight ,(set-bold 'semi-bold) :foreground ,organic-purple))))
-     `(font-lock-string-face ((t (:foreground ,organic-grass-green))) t)
-     `(font-lock-type-face ((t (:foreground ,organic-teal :weight ,(set-bold 'bold)))))
-     `(font-lock-variable-name-face ((,class (:width condensed :foreground ,organic-yellow))))
-     `(font-lock-warning-face ((,class (:foreground ,organic-error-red :weight ,(set-bold 'bold)))))
+      (organic-alum-1    "#eeeeec")
+      (organic-alum-2    "#d3d7cf")
+      (organic-alum-3    "#babdb6")
+      (organic-alum-6    "#2e3436")
 
-     ;; Button and link faces
-     `(link ((,class (:underline t :foreground ,organic-dark-blue))))
-     `(link-visited ((,class (:underline t :foreground ,organic-medium-blue))))
+      (organic-gray-0    "#E3F2E1")
+      (organic-gray-1    "#DAEADA")
+      (organic-gray-2    "#E5E5E5")
+      (organic-gray-3    "gray")
+      (organic-gray-4    "gray50")
+      (organic-gray-5    "DimGray")
+      (organic-gray-6    "gray28")
 
-     ;; Jabber
-     '(jabber-roster-user-chatty ((t (:inherit font-lock-type-face :bold tx))))
-     '(jabber-roster-user-online ((t (:inherit font-lock-keyword-face :bold t))))
-     `(jabber-roster-user-offline ((t (:foreground ,organic-fg :background ,organic-bg))))
-     '(jabber-roster-user-away ((t (:inherit font-lock-doc-face))))
-     '(jabber-roster-user-xa ((t (:inherit font-lock-doc-face))))
-     '(jabber-roster-user-dnd ((t (:inherit font-lock-comment-face))))
-     '(jabber-roster-user-error ((t (:inherit font-lock-warning-face))))
+      ;; gray70
+      ;; gray72
+      ;; gray80
 
-     '(jabber-title-small ((t (:height 1.2 :weight bold))))
-     '(jabber-title-medium ((t (:inherit jabber-title-small :height 1.2))))
-     '(jabber-title-large ((t (:inherit jabber-title-medium :height 1.2))))
+      ;; conditional styles that evaluate user-facing customization
+      ;; options
+      (organic-green-slant
+       (if organic-green-slanted-constructs
+           'italic
+         'normal))
 
-     '(jabber-chat-prompt-local ((t (:inherit font-lock-string-face :bold t))))
-     '(jabber-chat-prompt-foreign ((t (:inherit font-lock-function-name-face :bold nil))))
-     '(jabber-chat-prompt-system ((t (:inherit font-lock-comment-face :bold t))))
-     '(jabber-rare-time-face ((t (:inherit font-lock-function-name-face :bold nil))))
+      (organic-green-bold
+       (if organic-green-bold-constructs
+           'bold
+         'normal)))
 
-     '(jabber-activity-face ((t (:inherit jabber-chat-prompt-foreign))))
-     '(jabber-activity-personal-face ((t (:inherit jabber-chat-prompt-local :bold t))))
+  (custom-theme-set-faces
+   'organic-green
+   ;; essential styles
+   `(default ((,class (:foreground ,organic-fg :background ,organic-bg))))
 
-     ;; LaTeX
-     '(font-latex-bold-face ((t (:bold t :foreground "DarkOliveGreen"))))
-     '(font-latex-italic-face ((t (:italic t :foreground "DarkOliveGreen"))))
-     `(font-latex-math-face ((t (:foreground ,organic-yellow))))
-     '(font-latex-sedate-face ((t (:foreground "DimGray"))))
-     '(font-latex-string-face ((t (nil))))
-     `(font-latex-warning-face ((t (:bold t :weight semi-bold :foreground ,organic-orange))))
+   ;; base
+   `(bold ((,class (:weight bold))))
+   `(extra-bold ((,class (:weight extra-bold))))
+   `(semi-bold ((,class (:weight semi-bold))))
+   `(italic ((,class (:slant italic))))
+   `(error ((,class (:foreground ,organic-red-6 :weight bold))))
+   `(escape-glyph ((,class (:foreground ,organic-green-8))))
+   `(warning ((,class (:foreground ,organic-orange))))
+   `(success ((,class (:foreground ,organic-green-3))))
+   `(font-lock-builtin-face ((,class (:foreground ,organic-teal))))
+   `(font-lock-comment-face ((,class (:foreground ,organic-gray-4))))
+   `(font-lock-constant-face ((,class (:foreground ,organic-blue-4))))
+   `(font-lock-function-name-face ((,class (:foreground ,organic-blue-2 :weight extra-bold))))
+   `(font-lock-keyword-face ((,class (:foreground ,organic-purple :weight semi-bold))))
+   `(font-lock-string-face ((t (:foreground ,organic-green-4))) t)
+   `(font-lock-type-face ((t (:foreground ,organic-teal :weight bold))))
+   `(font-lock-variable-name-face ((,class (:foreground ,organic-yellow-5 :width condensed))))
+   `(font-lock-warning-face ((,class (:foreground ,organic-orange :weight bold))))
 
-     ;; quack
-     `(quack-pltish-paren-face ((((class color) (background light)) (:foreground ,organic-sea-eye-green))))
-     `(quack-pltish-keyword-face ((t (:foreground ,organic-purple :weight bold))))
+   ;; ui
+   `(cursor ((,class (:background ,organic-cursor-fg))))
+   `(fringe ((,class (:background ,organic-fringe-bg :foreground ,organic-fringe-fg))))
+   `(vertical-border ((,class (:foreground ,organic-fringe-fg))))
+   `(minibuffer-prompt ((,class (:foreground ,organic-blue-6 :weight bold))))
+   `(mode-line ((,class (:box (:line-width -1 :style released-button) :background ,organic-alum-2 :foreground ,organic-alum-6))))
+   `(mode-line-inactive ((,class (:box (:line-width -1 :style released-button) :background ,organic-alum-1 :foreground ,organic-alum-6))))
+   `(link ((,class (:underline t :foreground ,organic-blue-6))))
+   `(link-visited ((,class (:underline t :foreground ,organic-blue-4))))
+   `(highlight ((,class (:background ,organic-yellow-0))))
+   `(region ((,class (:background ,organic-yellow-1))))
+   `(lazy-highlight ((,class (:background ,organic-yellow-2 :inverse-video nil))))
+   `(isearch ((,class (:foreground ,organic-fg :background ,organic-yellow-3 :inverse-video nil))))
+   `(cua-rectangle ((,class (:background ,organic-yellow-1))))
+   `(secundary-selection ((,class (:background ,organic-blue-0))))
+   `(trailing-whitespace ((,class (:background ,organic-red-3))))
 
-     ;; js2-mode
-     `(js2-external-variable ((t (:foreground ,organic-dodger-blue))))
-     `(js2-function-param ((t (:foreground ,organic-teal))))
 
-     ;; clojure/CIDER
-     `(cider-result-overlay-face ((t (:background ,organic-bg :box (:line-width -1 :color ,organic-pair-yellow)))))
+   ;; external packages
+   ;;; Jabber
+   '(jabber-roster-user-chatty ((t (:inherit font-lock-type-face :bold t))))
+   '(jabber-roster-user-online ((t (:inherit font-lock-keyword-face :bold t))))
+   `(jabber-roster-user-offline ((t (:foreground ,organic-fg :background ,organic-bg))))
+   '(jabber-roster-user-away ((t (:inherit font-lock-doc-face))))
+   '(jabber-roster-user-xa ((t (:inherit font-lock-doc-face))))
+   '(jabber-roster-user-dnd ((t (:inherit font-lock-comment-face))))
+   '(jabber-roster-user-error ((t (:inherit font-lock-warning-face))))
+   '(jabber-title-small ((t (:height 1.2 :weight bold))))
+   '(jabber-title-medium ((t (:inherit jabber-title-small :height 1.2))))
+   '(jabber-title-large ((t (:inherit jabber-title-medium :height 1.2))))
+   '(jabber-chat-prompt-local ((t (:inherit font-lock-string-face :bold t))))
+   '(jabber-chat-prompt-foreign ((t (:inherit font-lock-function-name-face :bold nil))))
+   '(jabber-chat-prompt-system ((t (:inherit font-lock-comment-face :bold t))))
+   '(jabber-rare-time-face ((t (:inherit font-lock-function-name-face :bold nil))))
+   '(jabber-activity-face ((t (:inherit jabber-chat-prompt-foreign))))
+   '(jabber-activity-personal-face ((t (:inherit jabber-chat-prompt-local :bold t))))
 
-     ;; java
-     `(jdee-java-properties-font-lock-comment-face ((t (:foreground ,organic-gray))))
-     `(jdee-java-properties-font-lock-equal-face ((t (:foreground ,organic-dodger-blue))))
-     '(jdee-java-properties-font-lock-substitution-face ((t (:inherit font-lock-function-name-face :bold nil))))
-     '(jdee-java-properties-font-lock-class-name-face ((t (:inherit font-lock-constant-face :bold nil))))
-     '(jdee-java-properties-font-lock-value-face ((t (:inherit font-lock-string-face :bold nil))))
-     `(jdee-java-properties-font-lock-backslash-face ((t (:foreground ,organic-sea-eye-green))))
+   ;;; LaTeX
+   `(font-latex-bold-face ((t (:bold t :foreground ,organic-olive-1))))
+   `(font-latex-italic-face ((t (:italic t :foreground ,organic-olive-1))))
+   `(font-latex-math-face ((t (:foreground ,organic-yellow-5))))
+   `(font-latex-sedate-face ((t (:foreground ,organic-gray-5))))
+   '(font-latex-string-face ((t (nil))))
+   `(font-latex-warning-face ((t (:bold t :weight semi-bold :foreground ,organic-orange))))
 
-     ;; scala
-     `(scala-font-lock:var-face ((t (:foreground ,organic-orange))))
+   ;;; Quack
+   `(quack-pltish-paren-face ((((class color) (background light)) (:foreground ,organic-green-8))))
+   `(quack-pltish-keyword-face ((t (:foreground ,organic-purple :weight bold))))
 
-     ;; lsp
-     '(lsp-ui-doc-border ((t (:background "#E5E5E5"))))
-     `(lsp-ui-doc-background ((t (:background ,organic-tiny-highlight-green))))
-     `(lsp-ui-sideline-code-action ((t (:background ,organic-tiny-highlight-green :foreground ,organic-gray))))
+   ;;; js2-mode
+   `(js2-external-variable ((t (:foreground ,organic-blue-1))))
+   `(js2-function-param ((t (:foreground ,organic-teal))))
 
-     ;; Tcl
-     `(tcl-substitution-char-face ((t (:foreground ,organic-olive))))
+   ;; clojure/CIDER
+   `(cider-result-overlay-face ((t (:background ,organic-bg :box (:line-width -1 :color ,organic-yellow-1)))))
 
-     ;; erc
-     '(erc-action-face ((t (:foreground "gray" :weight bold))))
-     `(erc-command-indicator-face ((t (:foreground ,organic-dark-gray :weight bold))))
-     `(erc-nick-default-face ((t (:foreground ,organic-purple :weight bold))))
-     `(erc-input-face ((t (:foreground ,organic-dark-blue))))
-     '(erc-notice-face ((t (:foreground "dark sea green" :weight bold))))
-     `(erc-timestamp-face ((t (:foreground ,organic-grass-green :weight bold))))
+   ;;; Java
+   `(jdee-java-properties-font-lock-comment-face ((t (:foreground ,organic-gray-4))))
+   `(jdee-java-properties-font-lock-equal-face ((t (:foreground ,organic-blue-1))))
+   '(jdee-java-properties-font-lock-substitution-face ((t (:inherit font-lock-function-name-face :bold nil))))
+   '(jdee-java-properties-font-lock-class-name-face ((t (:inherit font-lock-constant-face :bold nil))))
+   '(jdee-java-properties-font-lock-value-face ((t (:inherit font-lock-string-face :bold nil))))
+   `(jdee-java-properties-font-lock-backslash-face ((t (:foreground ,organic-green-8))))
 
-     ;; circe
-     '(circe-server-face ((t (:foreground "dark sea green"))))
-     `(circe-prompt-face ((t (:foreground ,organic-dark-gray :background ,organic-minor-highlight-green :weight bold))))
-     `(circe-highlight-nick-face ((t (:foreground ,organic-orange))))
-     `(lui-time-stamp-face ((t (:foreground ,organic-grass-green))))
+   ;;; Scala
+   `(scala-font-lock:var-face ((t (:foreground ,organic-orange))))
 
-     ;; rst
-     '(rst-definition ((t (:inherit font-lock-constant-face))) t)
-     `(rst-level-1 ((t (:background ,organic-minor-highlight-green))) t)
-     `(rst-level-2 ((t (:background ,organic-minor-highlight-grey))))
-     `(rst-level-3 ((t (:background ,organic-minor-highlight-grey))))
-     `(rst-level-4 ((t (:background ,organic-minor-highlight-grey))))
-     `(rst-level-5 ((t (:background ,organic-minor-highlight-grey))))
-     `(rst-level-6 ((t (:background ,organic-minor-highlight-grey))))
-     '(rst-block ((t (:inherit font-lock-function-name-face :bold t))) t)
-     '(rst-external ((t (:inherit font-lock-constant-face))) t)
-     '(rst-directive ((t (:inheit font-lock-builtin-face))) t)
-     '(rst-literal ((t (:inheit font-lock-string-face))))
-     '(rst-emphasis1 ((t (:inherit italic))) t)
-     `(rst-adornment ((t (:bold t :foreground ,organic-medium-blue))))
+   ;;; Lsp
+   `(lsp-ui-doc-border ((t (:background ,organic-gray-2))))
+   `(lsp-ui-doc-background ((t (:background ,organic-green-0))))
+   `(lsp-ui-sideline-code-action ((t (:background ,organic-green-0 :foreground ,organic-gray-4))))
 
-     ;; whitespace-mode
-     `(whitespace-empty ((t (:background ,organic-bg :foreground ,alum-3))) t)
-     `(whitespace-indentation ((t (:background ,organic-bg :foreground ,alum-3))) t)
-     `(whitespace-newline ((t (:background ,organic-bg :foreground ,alum-3))) t)
-     `(whitespace-space-after-tab ((t (:background ,organic-bg :foreground ,alum-3))) t)
-     `(whitespace-tab ((t (:background ,organic-bg :foreground ,alum-3))) t)
-     `(whitespace-hspace ((t (:background ,organic-bg :foreground ,alum-3))) t)
-     `(whitespace-line ((t (:background ,organic-bg :foreground ,alum-3))) t)
-     `(whitespace-space ((t (:background ,organic-bg :foreground ,alum-3))) t)
-     `(whitespace-space-before-tab ((t (:background ,organic-bg :foreground ,alum-3))) t)
-     `(whitespace-trailing ((t (:background ,organic-bg :foreground ,organic-error-red))) t)
+   ;;; Tcl
+   `(tcl-substitution-char-face ((t (:foreground ,organic-olive-0))))
 
-     ;; log4j
-     '(log4j-font-lock-warn-face ((t (:inherit warning))))
+   ;;; Erc
+   `(erc-action-face ((t (:foreground ,organic-gray-3 :weight bold))))
+   `(erc-command-indicator-face ((t (:foreground ,organic-gray-6 :weight bold))))
+   `(erc-nick-default-face ((t (:foreground ,organic-purple :weight bold))))
+   `(erc-input-face ((t (:foreground ,organic-blue-6))))
+   `(erc-notice-face ((t (:foreground ,organic-green-9 :weight bold))))
+   `(erc-timestamp-face ((t (:foreground ,organic-green-4 :weight bold))))
 
-     ;; sh-mode
-     '(sh-heredoc ((t (:inherit font-lock-string-face))))
-     '(sh-quoted-exec ((t (:inherit font-lock-constant-face))))
+   ;; Circe
+   `(circe-server-face ((t (:foreground ,organic-green-9))))
+   `(circe-prompt-face ((t (:foreground ,organic-gray-5 :background ,organic-green-1 :weight bold))))
+   `(circe-highlight-nick-face ((t (:foreground ,organic-orange))))
+   `(lui-time-stamp-face ((t (:foreground ,organic-green-4))))
 
-     ;; ace-jump
-     '(ace-jump-face-foreground ((t (:foreground "red" :underline nil))) t)
+   ;;; Rst
+   '(rst-definition ((t (:inherit font-lock-constant-face))) t)
+   `(rst-level-1 ((t (:background ,organic-green-1))) t)
+   `(rst-level-2 ((t (:background ,organic-gray-1))))
+   `(rst-level-3 ((t (:background ,organic-gray-1))))
+   `(rst-level-4 ((t (:background ,organic-gray-1))))
+   `(rst-level-5 ((t (:background ,organic-gray-1))))
+   `(rst-level-6 ((t (:background ,organic-gray-1))))
+   '(rst-block ((t (:inherit font-lock-function-name-face :bold t))) t)
+   '(rst-external ((t (:inherit font-lock-constant-face))) t)
+   '(rst-directive ((t (:inheit font-lock-builtin-face))) t)
+   '(rst-literal ((t (:inheit font-lock-string-face))))
+   '(rst-emphasis1 ((t (:inherit italic))) t)
+   `(rst-adornment ((t (:bold t :foreground ,organic-blue-4))))
 
-     ;; diff
-     '(diff-indicator-added ((t (:foreground "#339933"))) t)
-     '(diff-added ((t (:foreground "#339933"))) t)
-     `(diff-indicator-removed ((t (:foreground ,red-2))) t)
-     `(diff-removed ((t (:foreground ,red-2))) t)
+   ;; Whitespace-Mode
+   `(whitespace-empty ((t (:background ,organic-bg :foreground ,organic-alum-3))) t)
+   `(whitespace-indentation ((t (:background ,organic-bg :foreground ,organic-alum-3))) t)
+   `(whitespace-newline ((t (:background ,organic-bg :foreground ,organic-alum-3))) t)
+   `(whitespace-space-after-tab ((t (:background ,organic-bg :foreground ,organic-alum-3))) t)
+   `(whitespace-tab ((t (:background ,organic-bg :foreground ,organic-alum-3))) t)
+   `(whitespace-hspace ((t (:background ,organic-bg :foreground ,organic-alum-3))) t)
+   `(whitespace-line ((t (:background ,organic-bg :foreground ,organic-alum-3))) t)
+   `(whitespace-space ((t (:background ,organic-bg :foreground ,organic-alum-3))) t)
+   `(whitespace-space-before-tab ((t (:background ,organic-bg :foreground ,organic-alum-3))) t)
+   `(whitespace-trailing ((t (:background ,organic-bg :foreground ,organic-red-6))) t)
 
-     ;; magit
-     '(magit-diff-add ((t (:foreground "#339933"))) t)
-     `(magit-diff-del ((t (:foreground ,red-2))) t)
-     '(magit-diff-added ((t (:foreground "#22aa22" :background "#ddffdd"))) t)
-     '(magit-diff-removed ((t (:foreground "#aa2222" :background "#ffdddd"))) t)
-     '(magit-diff-added-highlight ((t (:foreground "#22aa22" :background "#cceecc"))) t)
-     '(magit-diff-removed-highlight ((t (:foreground "#aa2222" :background "#eecccc"))) t)
-     `(magit-diff-context-highlight ((t (:background ,organic-bg :foreground "grey50"))) t)
-     `(magit-diff-file-heading-highlight ((t (:background ,organic-minor-highlight-green))) t)
-     `(magit-item-highlight ((t (:background ,organic-tiny-highlight-grey))) t)
-     `(magit-log-author ((t (:foreground ,organic-spring-green))) t)
-     `(magit-popup-argument ((t (:foreground ,organic-blue))) t)
-     `(magit-process-ok ((t (:foreground ,organic-grass-green))) t)
-     `(magit-section-highlight ((t (:background ,organic-minor-highlight-green))) t)
-     `(magit-branch-remote ((t (:foreground ,organic-olive))) t)
-     `(magit-section-heading ((t (:bold t :foreground ,organic-dark-yellow))) t)
+   ;;; Log4j
+   '(log4j-font-lock-warn-face ((t (:inherit warning))))
 
-     ;; git-gutter
-     '(git-gutter:added ((t (:foreground "#339933"))) t)
-     `(git-gutter:deleted ((t (:foreground ,red-2))) t)
-     `(git-gutter:modified ((t (:foreground ,organic-dodger-blue))) t)
+   ;;; sh-mode
+   '(sh-heredoc ((t (:inherit font-lock-string-face))))
+   '(sh-quoted-exec ((t (:inherit font-lock-constant-face))))
 
-     '(git-gutter-fr:added ((t (:foreground "PaleGreen3" :background "PaleGreen3"))) t)
-     '(git-gutter-fr:deleted ((t (:foreground "tomato1" :background "tomato1"))) t)
-     '(git-gutter-fr:modified ((t (:foreground "LightSkyBlue3" :background "LightSkyBlue3"))) t)
+   ;;; Ace-Jump
+   `(ace-jump-face-foreground ((t (:foreground ,organic-red-4 :underline nil))) t)
 
-     ;; org-mode
-     `(org-table ((t (:foreground ,organic-teal))) t)
-     '(org-level-1 ((t (:inherit font-lock-function-name-face :bold t))) t)
-     '(org-level-2 ((t (:inherit font-lock-variable-name-face :bold t))) t)
-     '(org-level-3 ((t (:inherit font-lock-keyword-face :bold t))) t)
-     `(org-level-4 ((t (:foreground ,organic-sea-eye-green :bold t))) t)
-     `(org-level-5 ((t (:foreground  ,organic-medium-blue :bold t))) t)
-     `(org-level-6 ((t (:foreground ,organic-teal :bold t))) t)
-     `(org-block ((,class (:foreground ,organic-fg))))
-     `(org-block-begin-line ((t (:foreground ,organic-medium-blue))) t)
-     `(org-block-end-line ((t (:foreground ,organic-medium-blue))) t)
+   ;;; Diff
+   `(diff-indicator-added ((t (:foreground ,organic-green-5))) t)
+   `(diff-added ((t (:foreground ,organic-green-5))) t)
+   `(diff-indicator-removed ((t (:foreground ,organic-red-5))) t)
+   `(diff-removed ((t (:foreground ,organic-red-5))) T)
 
-     ;; misc
-     `(nxml-element-local-name ((t (:foreground ,organic-flx-blue :weight normal))) t)
-     `(yas-field-highlight-face ((t (:background ,organic-highlight-lazy-yellow))))
-     `(idle-highlight ((t (:background ,organic-minor-highlight-yellow))) t)
-     `(comint-highlight-prompt ((t (:foreground ,organic-medium-blue :weight bold))) t)
+   ;;; Magit
+   `(magit-diff-add ((t (:foreground ,organic-green-5))) t)
+   `(magit-diff-del ((t (:foreground ,organic-red-5))) t)
+   `(magit-diff-added ((t (:foreground ,organic-green-7 :background "#ddffdd"))) t)
+   `(magit-diff-removed ((t (:foreground ,organic-red-6 :background ,organic-red-1))) t)
+   `(magit-diff-added-highlight ((t (:foreground ,organic-green-7 :background "#cceecc"))) t)
+   `(magit-diff-removed-highlight ((t (:foreground ,organic-red-6 :background ,organic-red-2))) t)
+   `(magit-diff-context-highlight ((t (:background ,organic-bg :foreground ,organic-gray-4))) t)
+   `(magit-diff-file-heading-highlight ((t (:background ,organic-green-1))) t)
+   `(magit-item-highlight ((t (:background ,organic-gray-0))) t)
+   `(magit-log-author ((t (:foreground ,organic-green-6))) t)
+   `(magit-popup-argument ((t (:foreground ,organic-blue-2))) t)
+   `(magit-process-ok ((t (:foreground ,organic-green-4))) t)
+   `(magit-section-highlight ((t (:background ,organic-green-1))) t)
+   `(magit-branch-remote ((t (:foreground ,organic-olive-0))) t)
+   `(magit-section-heading ((t (:bold t :foreground ,organic-yellow-5))) t)
 
-     `(flx-highlight-face  ((t (:foreground ,organic-flx-blue :bold t :underline t))) t)
+   ;; git-gutter  <TODO>
+   `(git-gutter:added ((t (:foreground ,organic-green-5))) t)
+   `(git-gutter:deleted ((t (:foreground ,organic-red-5))) t)
+   `(git-gutter:modified ((t (:foreground ,organic-blue-1))) t)
+   '(git-gutter-fr:added ((t (:foreground "PaleGreen3" :background "PaleGreen3"))) t)
+   '(git-gutter-fr:deleted ((t (:foreground "tomato1" :background "tomato1"))) t)
+   '(git-gutter-fr:modified ((t (:foreground "LightSkyBlue3" :background "LightSkyBlue3"))) t)
 
-     ;; powerline
-     `(powerline-active1 ((t (:background ,alum-3 :inherit mode-line))) t)
-     `(powerline-active2 ((t (:background ,alum-2 :inherit mode-line))) t)
-     '(powerline-inactive1  ((t (:background "grey70" :inherit mode-line-inactive))) t)
-     '(powerline-inactive2  ((t (:background "grey80" :inherit mode-line-inactive))) t)
+   ;;; Org-Mode
+   `(org-table ((t (:foreground ,organic-teal))) t)
+   '(org-level-1 ((t (:inherit font-lock-function-name-face :bold t))) t)
+   '(org-level-2 ((t (:inherit font-lock-variable-name-face :bold t))) t)
+   '(org-level-3 ((t (:inherit font-lock-keyword-face :bold t))) t)
+   `(org-level-4 ((t (:foreground ,organic-green-8 :bold t))) t)
+   `(org-level-5 ((t (:foreground  ,organic-blue-4 :bold t))) t)
+   `(org-level-6 ((t (:foreground ,organic-teal :bold t))) t)
+   `(org-block ((,class (:foreground ,organic-fg))))
+   `(org-block-begin-line ((t (:foreground ,organic-blue-4))) t)
+   `(org-block-end-line ((t (:foreground ,organic-blue-4))) t)
 
-     ;; tabbar
-     '(tabbar-button ((t :inherit tabbar-default :box (:line-width 1 :color "gray72"))))
-     '(tabbar-modified ((t (:inherit tabbar-default :foreground "#118811"
-                                     :bold t
-                                     :box (:line-width 1 :color "white"
-                                                       :style released-button)))))
-     `(tabbar-selected ((t :inherit tabbar-default
-                           :box (:line-width 1 :color "white" :style pressed-button)
-                           :foreground ,alum-6 :bold t)))
-     '(tabbar-selected-modified ((t :inherit tabbar-selected)))
+   ;;; Misc
+   `(nxml-element-local-name ((t (:foreground ,organic-blue-3 :weight normal))) t)
+   `(yas-field-highlight-face ((t (:background ,organic-yellow-2))))
+   `(idle-highlight ((t (:background ,organic-yellow-0))) t)
+   `(comint-highlight-prompt ((t (:foreground ,organic-blue-4 :weight bold))) t)
+   `(flx-highlight-face  ((t (:foreground ,organic-blue-3 :bold t :underline t))) t)
 
-     ;; web-mode
-     `(web-mode-current-element-highlight-face
-       ((,class (:background ,organic-minor-highlight-green))))
-     `(web-mode-html-tag-face ((t (:foreground ,organic-dark-gray))) t)
-     `(web-mode-html-attr-name-face ((t (:foreground ,organic-cornflower-blue))) t)
-     `(web-mode-doctype-face ((t (:foreground ,organic-medium-blue))) t)
-     `(web-mode-comment-face ((t (:foreground ,organic-gray)) t))
-     `(web-mode-css-selector-face ((t (:foreground ,organic-teal))) t)
-     `(web-mode-function-call-face ((t :inherit ,organic-fg)))
-     `(web-mode-function-name-face ((t :inherit font-lock-function-name-face)))
+   ;; powerline <TODO>
+   `(powerline-active1 ((t (:background ,organic-alum-3 :inherit mode-line))) t)
+   `(powerline-active2 ((t (:background ,organic-alum-2 :inherit mode-line))) t)
+   '(powerline-inactive1  ((t (:background "grey70" :inherit mode-line-inactive))) t)
+   '(powerline-inactive2  ((t (:background "grey80" :inherit mode-line-inactive))) t)
 
-     `(eldoc-highlight-function-argument
-       ((t (:foreground ,organic-grass-green :weight bold))) t)
+   ;; tabbar <TODO>
+   '(tabbar-button ((t :inherit tabbar-default :box (:line-width 1 :color "gray72"))))
+   `(tabbar-modified ((t (:inherit tabbar-default :foreground "#118811"
+                                   :bold t
+                                   :box (:line-width 1 :color ,organic-white
+                                                     :style released-button)))))
+   `(tabbar-selected ((t :inherit tabbar-default
+                         :box (:line-width 1 :color ,organic-white :style pressed-button)
+                         :foreground ,organic-alum-6 :bold t)))
+   '(tabbar-selected-modified ((t :inherit tabbar-selected)))
 
-     `(table-cell ((t (:foreground ,organic-fg :background ,organic-tiny-highlight-green))) t)
+   ;;; Web-Mode
+   `(web-mode-current-element-highlight-face ((,class (:background ,organic-green-1))))
+   `(web-mode-html-tag-face ((t (:foreground ,organic-gray-6))) t)
+   `(web-mode-html-attr-name-face ((t (:foreground ,organic-blue-5))) t)
+   `(web-mode-doctype-face ((t (:foreground ,organic-blue-4))) t)
+   `(web-mode-comment-face ((t (:foreground ,organic-gray-4)) t))
+   `(web-mode-css-selector-face ((t (:foreground ,organic-teal))) t)
+   `(web-mode-function-call-face ((t :inherit ,organic-fg)))
+   `(web-mode-function-name-face ((t :inherit font-lock-function-name-face)))
 
-     ;; dired
-     `(diredp-dir-heading ((t (:background ,organic-tiny-highlight-green))))
-     `(diredp-dir-name ((t (:foreground ,alum-6))))
-     `(diredp-file-name ((t (:foreground ,organic-fg))))
-     `(diredp-file-suffix ((t (:foreground ,organic-teal))))
-     ;; dired+
-     `(diredp-compressed-file-suffix ((t (:foreground ,organic-orange))))
+   `(eldoc-highlight-function-argument
+     ((t (:foreground ,organic-green-4 :weight bold))) t)
 
-     ;;Highlight pair parentheses
-     `(show-paren-match ((t (:background ,organic-pair-yellow))))
-     `(show-paren-mismatch ((t (:background ,organic-minor-highlight-red))))
+   `(table-cell ((t (:foreground ,organic-fg :background ,organic-green-0))) T)
 
-     ;; rainbow-delimiters
-     ;; (1 (2 (3 (4 (5 (6 (7 (8 (9 (10 (11 (12))))))))))))
-     `(rainbow-delimiters-depth-1-face ((t (:foreground "#666666" :background ,organic-bg))))
-     `(rainbow-delimiters-depth-2-face ((t (:foreground "#5544EE" :background ,organic-bg))))
-     `(rainbow-delimiters-depth-3-face ((t (:foreground "#2265DC" :background ,organic-bg))))
-     `(rainbow-delimiters-depth-4-face ((t (:foreground "#00A89B" :background ,organic-bg))))
-     `(rainbow-delimiters-depth-5-face ((t (:foreground "#229900" :background ,organic-bg))))
-     `(rainbow-delimiters-depth-6-face ((t (:foreground "#999900" :background ,organic-bg))))
-     `(rainbow-delimiters-depth-7-face ((t (:foreground "#F57900" :background ,organic-bg))))
-     `(rainbow-delimiters-depth-8-face ((t (:foreground "#EE66E8" :background ,organic-bg))))
-     `(rainbow-delimiters-depth-9-face ((t (:foreground "purple"  :background ,organic-bg))))
-     )))
+   ;;; Dired
+   `(diredp-dir-heading ((t (:background ,organic-green-0))))
+   `(diredp-dir-name ((t (:foreground ,organic-alum-6))))
+   `(diredp-file-name ((t (:foreground ,organic-fg))))
+   `(diredp-file-suffix ((t (:foreground ,organic-teal))))
 
-(custom-theme-set-variables
- 'organic-green
+   ;;; Dired+
+   `(diredp-compressed-file-suffix ((t (:foreground ,organic-orange))))
 
- ;; lisp parentheses rainbow
- `(hl-paren-colors '("#326B6B"))
- `(hl-paren-background-colors
-   '("#00FF99" "#CCFF99" "#FFCC99" "#FF9999" "#FF99CC"
-     "#CC99FF" "#9999FF" "#99CCFF" "#99FFCC" "#7FFF00"))
+   ;;Highlight pair parentheses
+   `(show-paren-match ((t (:background ,organic-yellow-1))))
+   `(show-paren-mismatch ((t (:background ,organic-red-1))))
 
- ;; fill-column-indicator
- `(fci-rule-color "gray80")
+   ;;; Rainbow-Delimiters
+   ;; (1 (2 (3 (4 (5 (6 (7 (8 (9 (10 (11 (12))))))))))))
+   `(rainbow-delimiters-depth-1-face ((t (:foreground "#666666" :background ,organic-bg))))
+   `(rainbow-delimiters-depth-2-face ((t (:foreground "#5544EE" :background ,organic-bg))))
+   `(rainbow-delimiters-depth-3-face ((t (:foreground "#2265DC" :background ,organic-bg))))
+   `(rainbow-delimiters-depth-4-face ((t (:foreground "#00A89B" :background ,organic-bg))))
+   `(rainbow-delimiters-depth-5-face ((t (:foreground "#229900" :background ,organic-bg))))
+   `(rainbow-delimiters-depth-6-face ((t (:foreground "#999900" :background ,organic-bg))))
+   `(rainbow-delimiters-depth-7-face ((t (:foreground "#F57900" :background ,organic-bg))))
+   `(rainbow-delimiters-depth-8-face ((t (:foreground "#EE66E8" :background ,organic-bg))))
+   `(rainbow-delimiters-depth-9-face ((t (:foreground "purple"  :background ,organic-bg))))
 
- ;; marker
- `(highlight-symbol-colors
-   '("#FFF68F" "#ADFF2F" "#83DDFF" "#AB82FF" "#66CDAA"
-     "#FF8C00" "#FF6EB4" "#809FFF" "#9AFF9A"))
-
- ;; org-mode code blocks
- `(org-src-block-faces '(("emacs-lisp" (:background "#F0FFF0"))
-                         ("dot" (:foreground "gray50")))))
+   ))
 
 ;;;###autoload
-(when load-file-name
+(when (and (boundp 'custom-theme-load-path) load-file-name)
   (add-to-list 'custom-theme-load-path
                (file-name-as-directory (file-name-directory load-file-name))))
 
 (provide-theme 'organic-green)
-
 ;;; organic-green-theme.el ends here

--- a/organic-green-theme.el
+++ b/organic-green-theme.el
@@ -89,6 +89,7 @@ The theme needs to be reloaded after changing anything in this group."
       (organic-yellow-4  "#8B6508")
       (organic-yellow-5  "#B8860B")
 
+      (organic-yellow-green-0 "#BFFF00")
 
       (organic-purple    (if        organic-green-bold-constructs "#912CEE" "#A020F0"))
       (organic-orange    "#CE5C00")
@@ -165,11 +166,11 @@ The theme needs to be reloaded after changing anything in this group."
    `(mode-line-inactive ((,class (:box (:line-width -1 :style released-button) :background ,organic-alum-1 :foreground ,organic-alum-6))))
    `(link ((,class (:underline t :foreground ,organic-blue-6))))
    `(link-visited ((,class (:underline t :foreground ,organic-blue-4))))
-   `(highlight ((,class (:background ,organic-yellow-0))))
+   `(highlight ((,class (:background ,organic-green-1))))
    `(region ((,class (:background ,organic-yellow-1))))
    `(lazy-highlight ((,class (:background ,organic-yellow-2 :inverse-video nil))))
    `(isearch ((,class (:foreground ,organic-fg :background ,organic-yellow-3 :inverse-video nil))))
-   `(cua-rectangle ((,class (:background ,organic-yellow-1))))
+   `(cua-rectangle ((,class (:background ,organic-yellow-green-0))))
    `(secundary-selection ((,class (:background ,organic-blue-0))))
    `(trailing-whitespace ((,class (:background ,organic-red-3))))
 

--- a/organic-green-theme.el
+++ b/organic-green-theme.el
@@ -358,7 +358,7 @@ The theme needs to be reloaded after changing anything in this group."
    `(web-mode-doctype-face ((t (:foreground ,organic-blue-4))) t)
    `(web-mode-comment-face ((t (:foreground ,organic-gray-4)) t))
    `(web-mode-css-selector-face ((t (:foreground ,organic-teal))) t)
-   `(web-mode-function-call-face ((t :inherit ,organic-fg)))
+   `(web-mode-function-call-face ((t (:foreground ,organic-fg))) t)
    `(web-mode-function-name-face ((t :inherit font-lock-function-name-face)))
 
    `(eldoc-highlight-function-argument

--- a/organic-green-theme.el
+++ b/organic-green-theme.el
@@ -32,13 +32,8 @@
 The theme needs to be reloaded after changing anything in this group."
   :group 'faces)
 
-(defcustom organic-green-bold-constructs nil
-  "Use bold text in more code constructs."
-  :type 'boolean
-  :group 'organic-green)
-
-(defcustom organic-green-slanted-constructs nil
-  "Use slanted text in more code constructs (italics or oblique)."
+(defcustom organic-green-boldless nil
+  "Use bold text in less code constructs."
   :type 'boolean
   :group 'organic-green)
 
@@ -91,7 +86,7 @@ The theme needs to be reloaded after changing anything in this group."
 
       (organic-yellow-green-0 "#BFFF00")
 
-      (organic-purple    (if        organic-green-bold-constructs "#912CEE" "#A020F0"))
+      (organic-purple    (if organic-green-boldless "#912CEE" "#A020F0"))
       (organic-orange    "#CE5C00")
 
       (organic-red-0     "#FFF0F0")
@@ -123,15 +118,20 @@ The theme needs to be reloaded after changing anything in this group."
 
       ;; conditional styles that evaluate user-facing customization
       ;; options
-      (organic-green-slant
-       (if organic-green-slanted-constructs
-           'italic
-         'normal))
-
       (organic-green-bold
-       (if organic-green-bold-constructs
-           'bold
-         'normal)))
+       (if organic-green-boldless
+           'normal
+         'bold))
+
+      (organic-green-extra-bold
+       (if organic-green-boldless
+           'normal
+         'extra-bold))
+
+      (organic-green-semi-bold
+       (if organic-green-boldless
+           'normal
+         'semi-bold)))
 
   (custom-theme-set-faces
    'organic-green
@@ -143,19 +143,19 @@ The theme needs to be reloaded after changing anything in this group."
    `(extra-bold ((,class (:weight extra-bold))))
    `(semi-bold ((,class (:weight semi-bold))))
    `(italic ((,class (:slant italic))))
-   `(error ((,class (:foreground ,organic-red-6 :weight bold))))
+   `(error ((,class (:foreground ,organic-red-6 :weight ,organic-green-bold))))
    `(escape-glyph ((,class (:foreground ,organic-green-8))))
    `(warning ((,class (:foreground ,organic-orange))))
    `(success ((,class (:foreground ,organic-green-3))))
    `(font-lock-builtin-face ((,class (:foreground ,organic-teal))))
    `(font-lock-comment-face ((,class (:foreground ,organic-gray-4))))
    `(font-lock-constant-face ((,class (:foreground ,organic-blue-4))))
-   `(font-lock-function-name-face ((,class (:foreground ,organic-blue-2 :weight extra-bold))))
-   `(font-lock-keyword-face ((,class (:foreground ,organic-purple :weight semi-bold))))
+   `(font-lock-function-name-face ((,class (:foreground ,organic-blue-2 :weight ,organic-green-extra-bold))))
+   `(font-lock-keyword-face ((,class (:foreground ,organic-purple :weight ,organic-green-semi-bold))))
    `(font-lock-string-face ((t (:foreground ,organic-green-4))) t)
-   `(font-lock-type-face ((t (:foreground ,organic-teal :weight bold))))
+   `(font-lock-type-face ((t (:foreground ,organic-teal :weight ,organic-green-bold))))
    `(font-lock-variable-name-face ((,class (:foreground ,organic-yellow-5 :width condensed))))
-   `(font-lock-warning-face ((,class (:foreground ,organic-orange :weight bold))))
+   `(font-lock-warning-face ((,class (:foreground ,organic-orange :weight ,organic-green-bold))))
 
    ;; ui
    `(cursor ((,class (:background ,organic-cursor-fg))))
@@ -290,7 +290,7 @@ The theme needs to be reloaded after changing anything in this group."
    `(diff-indicator-removed ((t (:foreground ,organic-red-5))) t)
    `(diff-removed ((t (:foreground ,organic-red-5))) T)
 
-   ;;; Magit
+   ;; magit <TODO>
    `(magit-diff-add ((t (:foreground ,organic-green-5))) t)
    `(magit-diff-del ((t (:foreground ,organic-red-5))) t)
    `(magit-diff-added ((t (:foreground ,organic-green-7 :background "#ddffdd"))) t)


### PR DESCRIPTION
Now I know the pain rsrsrs. Fixes #2 

there are too many "small variations" of colors, if you use
`rainbow-mode` in this file you will notice now. There are several
changes that I made documented in this [org-table
](http://ix.io/2iEC)
There are still two or three TODOs in the file, but I would like to
ask about decreasing the number of color variations to be more
consistent.

For example, the faces for `added,modified,deleted` of `magit`,
`git-gutter` and `diff` should be the same?

In the end of the file, I could not find in the packages examples you
provide me how to define those colors properly:

```elisp
;; lisp parentheses rainbow
 `(hl-paren-colors '("#326B6B"))
 `(hl-paren-background-colors
   '("#00FF99" "#CCFF99" "#FFCC99" "#FF9999" "#FF99CC"
     "#CC99FF" "#9999FF" "#99CCFF" "#99FFCC" "#7FFF00"))

 ;; fill-column-indicator
 `(fci-rule-color "gray80")

 ;; marker
 `(highlight-symbol-colors
   '("#FFF68F" "#ADFF2F" "#83DDFF" "#AB82FF" "#66CDAA"
     "#FF8C00" "#FF6EB4" "#809FFF" "#9AFF9A"))

 ;; org-mode code blocks
 `(org-src-block-faces '(("emacs-lisp" (:background "#F0FFF0"))
                         ("dot" (:foreground "gray50"))))
```

I am currently using this new version and no major harm seems to be
happening... at least yet. =)

Thanks!

